### PR TITLE
hotfix: hdbscan 빌드를 위한 build-essential 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@ FROM python:3.12-slim AS builder
 
 WORKDIR /app
 
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 


### PR DESCRIPTION


## 📌 관련 이슈
- Closes #25 

## ✨ 작업 내용 (Summary)
- hdbscan 패키지 빌드 시 gcc 컴파일러가 필요하여 Dockerfile 빌더 스테이지에 build-essential 설치 단계 추가


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

