### PR TITLE
refactor: AnalyticsService 동시성 제한 제거 및 재시도 횟수 증가

### DIFF
--- a/app/core/retry_policy.py
+++ b/app/core/retry_policy.py
@@ -23,8 +23,8 @@ RETRYABLE_EXCEPTIONS = (
 # Bedrock API 호출용 재시도 decorator (동기/비동기 모두 지원)
 # Tenacity가 자동으로 sync/async 함수를 감지하여 처리
 bedrock_retry = retry(
-    stop=stop_after_attempt(3),  # 총 3회 시도 (최초 1회 + 재시도 2회)
-    wait=wait_exponential(multiplier=1, min=1, max=2),  # 1초 → 2초
+    stop=stop_after_attempt(4),  # 총 4회 시도 (최초 1회 + 재시도 3회)
+    wait=wait_exponential(multiplier=1, min=1, max=4),  # 1초 → 4초
     retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
     before_sleep=before_sleep_log(logger, logging.WARNING),
 )

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -63,10 +63,6 @@ class AnalyticsService:
         self.kiwi = Kiwi()  # 한국어 형태소 분석기
         logger.info("✅ Kiwi 형태소 분석기 초기화 완료")
 
-        # 동시성 제어 (Bedrock Throttling 방지)
-        # 동시에 최대 2개의 LLM 분석 작업만 수행
-        self.concurrency_limit = asyncio.Semaphore(2)
-
     # =========================================================================
     # Step 1: Data Loading
     # =========================================================================
@@ -335,8 +331,7 @@ class AnalyticsService:
             chain = prompt | self.bedrock_service.chat_model
             docs_text = "\n".join([f"- {doc}" for doc in documents])
 
-            async with self.concurrency_limit:
-                response = await chain.ainvoke({"answers": docs_text})
+            response = await chain.ainvoke({"answers": docs_text})
 
             return self._parse_llm_json(response.content)
 
@@ -377,8 +372,7 @@ class AnalyticsService:
             chain = prompt | self.bedrock_service.chat_model
             docs_text = "\n".join([f"- {doc}" for doc in documents[:10]])
 
-            async with self.concurrency_limit:
-                response = await chain.ainvoke({"answers": docs_text})
+            response = await chain.ainvoke({"answers": docs_text})
 
             result = self._parse_llm_json(response.content)
             return result.get("summary", "분석 불가")
@@ -407,8 +401,7 @@ class AnalyticsService:
             chain = prompt | self.bedrock_service.chat_model
             summaries_text = "\n".join([f"- {s}" for s in cluster_summaries])
 
-            async with self.concurrency_limit:
-                response = await chain.ainvoke({"cluster_summaries": summaries_text})
+            response = await chain.ainvoke({"cluster_summaries": summaries_text})
 
             result = self._parse_llm_json(response.content)
             return result.get("meta_summary", "")


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #46 

## ✨ 작업 내용 (Summary)
- [x] Titan v2와 claude sonnet 3.5에 대해 us-west-1지역에 각각 동시에 1000회의 요청 테스트
- [x] AnalyticsService semaphore 제거
- [x] retry_policy 최대 재시도 횟수 3회에서 4회로 증가 


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?

