### PR TITLE
fix: 유효성 평가 시 LLM 검증 로직 재적용

### DIFF
--- a/app/agents/survey_nodes.py
+++ b/app/agents/survey_nodes.py
@@ -149,7 +149,7 @@ class SurveyNodes:
     async def _generate_redirect_message(self, state: SurveyState) -> str:
         """OFF_TOPIC 재질문 생성"""
         question = state["current_question"]
-        return f"그 부분도 좋은 의견이네요! 혹시 원래 질문으로 돌아가서, {question.rstrip('?')}에 대해서는 어떻게 생각하세요?"
+        return f"그 부분도 좋은 의견이네요! 혹시 원래 질문에 답해주시겠어요?"
 
     async def _generate_clarify_message(self, state: SurveyState, validity: ValidityType) -> str:
         """AMBIGUOUS/CONTRADICTORY 명확화 질문"""

--- a/app/services/validity_service.py
+++ b/app/services/validity_service.py
@@ -85,27 +85,43 @@ class ValidityService:
     # 메인 평가 메소드
     # =========================================================================
 
-    async def evaluate_validity(
-        self,
-        answer: str,
-        current_question: str,
-    ) -> ValidityResult:
-        """
-        유효성 평가 (규칙 기반만 사용, LLM 호출 X)
+    # async def evaluate_validity(
+    #     self,
+    #     answer: str,
+    #     current_question: str,
+    # ) -> ValidityResult:
+    #     """
+    #     유효성 평가 (규칙 기반만 사용, LLM 호출 X)
 
-        모든 응답은 규칙으로 판정:
-        - 빈 응답/구두점만 → UNINTELLIGIBLE
-        - 그 외 모두 → VALID
-        """
-        result = self.preprocess_validity(answer)
-        if result is not None:
-            return result
+    #     모든 응답은 규칙으로 판정:
+    #     - 빈 응답/구두점만 → UNINTELLIGIBLE
+    #     - 그 외 모두 → VALID
+    #     """
+    #     result = self.preprocess_validity(answer)
+    #     if result is not None:
+    #         return result
 
-        # 혹시 여기 오면 VALID로 폴백 (안전장치)
-        logger.info("✅ 기본 VALID 폴백")
-        return ValidityResult(
-            validity=ValidityType.VALID,
-            confidence=0.9,
-            reason="기본 VALID 폴백",
-            source="fallback",
+    #     # 혹시 여기 오면 VALID로 폴백 (안전장치)
+    #     logger.info("✅ 기본 VALID 폴백")
+    #     return ValidityResult(
+    #         validity=ValidityType.VALID,
+    #         confidence=0.9,
+    #         reason="기본 VALID 폴백",
+    #         source="fallback",
+    #     )
+
+
+    async def evaluate_validity(self, answer: str, current_question: str) -> ValidityResult:
+        # 1차: 규칙 기반 (명백한 케이스)
+        rule_result = self.preprocess_validity(answer)
+
+        # UNINTELLIGIBLE은 규칙으로 확정
+        if rule_result and rule_result.validity == ValidityType.UNINTELLIGIBLE:
+            return rule_result
+
+        # 2차: LLM 기반 (OFF_TOPIC, AMBIGUOUS, REFUSAL 등 판단)
+        llm_result = await self.bedrock_service.evaluate_validity_async(
+            answer=answer,
+            current_question=current_question,
         )
+        return llm_result


### PR DESCRIPTION


## 📌 관련 이슈
- Closes #81 

## ✨ 작업 내용 (Summary)
- ValidityService: 규칙 기반 평가 후 LLM을 활용하여 상세 유효성(OFF_TOPIC 등)을 판별하도록 변경
- SurveyNodes: OFF_TOPIC 리다이렉트 메시지를 더 간결하고 자연스러운 문구로 수정


## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [x] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [x] 빌드 및 테스트가 통과하였는가?