### PR TITLE
refactor: LangGraph 상태 관리 및 SSE 스트리밍 로직 전면 리팩토링

### DIFF
--- a/app/schemas/survey.py
+++ b/app/schemas/survey.py
@@ -35,6 +35,7 @@ class QuestionType(str, Enum):
     OPENING = "OPENING"
     FIXED = "FIXED"
     TAIL = "TAIL"
+    RETRY = "RETRY"
 
 
 class ValidityType(str, Enum):

--- a/app/services/interaction_service.py
+++ b/app/services/interaction_service.py
@@ -31,112 +31,193 @@ class InteractionService:
         self, request: SurveyInteractionRequest
     ) -> AsyncGenerator[str, None]:
         """
-        SSE 스트리밍으로 답변 분석 및 응답 생성.
+        SSE 스트리밍으로 답변 분석 및 응답 생성 (실시간 astream_events 기반).
         """
         try:
+            logger.info(f"🚀 stream_interaction 시작: session={request.session_id}")
             yield self._sse_event("start", {"status": "processing", "phase": "main"})
 
-            # =====================================================
-            # LangGraph 입력 상태 구성
-            # =====================================================
-            input_state = {
-                "session_id": request.session_id,
-                "user_answer": request.user_answer,
-                "current_question": request.current_question,
-                "game_info": request.game_info,
-                "conversation_history": request.conversation_history,
-                "current_tail_count": request.current_tail_count or request.probe_count or 0,
-                "max_tail_questions": request.max_tail_questions or 2,
-                "retry_count": request.retry_count or 0,
-                "current_question_order": request.current_question_order,
-                "total_questions": request.total_questions,
-            }
+            input_state = self._build_input_state(request)
+            logger.info(f"📋 입력 상태 구성 완료: question={request.current_question[:30]}...")
 
-            # =====================================================
-            # LangGraph 실행 (ainvoke로 전체 실행)
-            # =====================================================
-            final_state = await self.workflow.ainvoke(input_state)
+            # 상태 누적용 변수
+            final_state = {}
+            message_buffer = []
+            is_streaming_active = False
+            active_streaming_run_id = None
 
-            # =====================================================
-            # SSE 이벤트 순차 전송
-            # =====================================================
+            # 핵심: astream_events로 LLM 토큰 스트리밍 캡처
+            logger.info("🔄 astream_events 시작...")
+            event_count = 0
+            async for event in self.workflow.astream_events(input_state, version="v2"):
+                try:
+                    event_count += 1
+                    event_kind = event.get("event", "")
+                    event_name = event.get("name", "")
+                    run_id = event.get("run_id", "")
 
-            # 1. 유효성 결과
-            if final_state.get("validity"):
-                yield self._sse_event("validity_result", {
-                    "validity": final_state["validity"].value,
-                    "confidence": final_state.get("validity_confidence", 0),
-                    "reason": final_state.get("validity_reason", ""),
-                    "source": final_state.get("validity_source", ""),
-                })
+                    # 디버그 로깅 (처음 몇 개 이벤트만)
+                    if event_count <= 10:
+                        logger.debug(f"📨 Event #{event_count}: kind={event_kind}, name={event_name}")
 
-            # 2. 품질 결과 (VALID일 때만)
-            if final_state.get("quality"):
-                yield self._sse_event("quality_result", {
-                    "quality": final_state["quality"].value,
-                    "thickness": final_state.get("thickness"),
-                    "thickness_evidence": final_state.get("thickness_evidence", []),
-                    "richness": final_state.get("richness"),
-                    "richness_evidence": final_state.get("richness_evidence", []),
-                })
+                    # LLM 스트리밍 시작 감지 (probe_llm 체인 또는 ChatBedrock)
+                    if event_kind == "on_chat_model_start":
+                        is_streaming_active = True
+                        active_streaming_run_id = run_id
+                        logger.info(f"🎬 LLM 스트리밍 시작: {event_name}")
 
-            # 3. 분석 결과
-            action = final_state.get("action", SurveyAction.PASS_TO_NEXT)
+                    # LLM 토큰 스트리밍
+                    elif event_kind == "on_chat_model_stream" and is_streaming_active:
+                        chunk_content = self._extract_chunk_content(event)
+                        if chunk_content:
+                            message_buffer.append(chunk_content)
+                            yield self._sse_event("continue", {"content": chunk_content})
+
+                    # LLM 스트리밍 종료
+                    elif event_kind == "on_chat_model_end" and run_id == active_streaming_run_id:
+                        is_streaming_active = False
+                        active_streaming_run_id = None
+                        logger.info(f"🏁 LLM 스트리밍 종료, 토큰 수: {len(message_buffer)}")
+
+                    # 노드 완료 시 SSE 이벤트 전송
+                    elif event_kind == "on_chain_end":
+                        output = event.get("data", {}).get("output", {})
+
+                        if isinstance(output, dict):
+                            final_state.update(output)
+
+                        # 노드별 이벤트 매핑
+                        sse_event = self._map_node_to_sse_event(event_name, output, final_state)
+                        if sse_event:
+                            yield sse_event
+
+                        # 메시지 생성 완료 이벤트 (generate_probe 또는 generate_retry 노드 완료 시)
+                        if event_name in ["generate_probe", "generate_retry"]:
+                            logger.info(f"✅ 노드 완료: {event_name}, buffer_len={len(message_buffer)}")
+
+                            # generate_retry는 LLM을 사용하지 않으므로 수동 스트리밍
+                            if event_name == "generate_retry" and not message_buffer:
+                                message = final_state.get("generated_message", "")
+                                if message:
+                                    for char in message:
+                                        yield self._sse_event("continue", {"content": char})
+
+                            complete_event = self._emit_message_complete(event_name, final_state, message_buffer)
+                            if complete_event:
+                                yield complete_event
+                            message_buffer = []
+
+                except Exception as event_error:
+                    logger.warning(f"⚠️ Event 처리 오류 (계속 진행): {event_error}")
+                    continue
+
+            # 최종 done 이벤트
+            logger.info(f"🏁 스트리밍 완료, 총 이벤트 수: {event_count}")
+            yield self._build_done_event(final_state)
+
+        except GeneratorExit:
+            logger.warning("⚠️ 클라이언트가 연결을 종료함")
+        except Exception as e:
+            logger.error(f"Streaming Error: {e}", exc_info=True)
+            yield self._sse_event("error", {"message": str(e)})
+
+    def _build_input_state(self, request: SurveyInteractionRequest) -> dict:
+        """LangGraph 입력 상태 구성"""
+        return {
+            "session_id": request.session_id,
+            "user_answer": request.user_answer,
+            "current_question": request.current_question,
+            "game_info": request.game_info,
+            "conversation_history": request.conversation_history,
+            "current_tail_count": request.current_tail_count or request.probe_count or 0,
+            "max_tail_questions": request.max_tail_questions or 2,
+            "retry_count": request.retry_count or 0,
+            "current_question_order": request.current_question_order,
+            "total_questions": request.total_questions,
+        }
+
+    def _extract_chunk_content(self, event: dict) -> str:
+        """astream_events 이벤트에서 청크 텍스트 추출"""
+        chunk = event.get("data", {}).get("chunk")
+        if not chunk:
+            return ""
+        content = chunk.content
+        if isinstance(content, list):
+            return "".join(
+                item.get("text", str(item)) if isinstance(item, dict) else str(item)
+                for item in content
+            )
+        return content if content else ""
+
+    def _map_node_to_sse_event(self, node_name: str, output: dict, final_state: dict) -> str | None:
+        """노드 완료 시 SSE 이벤트 매핑"""
+        if node_name == "validate" and output.get("validity"):
+            return self._sse_event("validity_result", {
+                "validity": output["validity"].value,
+                "confidence": output.get("validity_confidence", 0),
+                "reason": output.get("validity_reason", ""),
+                "source": output.get("validity_source", ""),
+            })
+
+        if node_name == "evaluate_quality" and output.get("quality"):
+            return self._sse_event("quality_result", {
+                "quality": output["quality"].value,
+                "thickness": output.get("thickness"),
+                "thickness_evidence": output.get("thickness_evidence", []),
+                "richness": output.get("richness"),
+                "richness_evidence": output.get("richness_evidence", []),
+            })
+
+        if node_name in ["pass_to_next", "generate_probe", "generate_retry"]:
+            action = output.get("action", SurveyAction.PASS_TO_NEXT)
             action_value = action.value if hasattr(action, 'value') else str(action)
-
-            yield self._sse_event("analyze_answer", {
+            return self._sse_event("analyze_answer", {
                 "action": action_value,
-                "analysis": final_state.get("analysis", ""),
-                "should_end": final_state.get("should_end", False),
-                "end_reason": final_state["end_reason"].value if final_state.get("end_reason") else None,
+                "analysis": output.get("analysis", ""),
+                "should_end": output.get("should_end", False),
+                "end_reason": output.get("end_reason").value if output.get("end_reason") else None,
+                "probe_type": output.get("probe_type"),
+            })
+
+        if node_name == "generate_reaction" and output.get("reaction"):
+            return self._sse_event("reaction", {"reaction_text": output["reaction"]})
+
+        return None
+
+    def _emit_message_complete(self, node_name: str, final_state: dict, message_buffer: list) -> str:
+        """메시지 생성 완료 이벤트 생성"""
+        message = "".join(message_buffer).strip() or final_state.get("generated_message", "")
+
+        if node_name == "generate_retry":
+            return self._sse_event("retry_request", {
+                "message": message,
+                "followup_type": final_state.get("followup_type", "clarify"),
+            })
+
+        if node_name == "generate_probe":
+            return self._sse_event("generate_tail_complete", {
+                "message": message,
+                "tail_question_count": (final_state.get("current_tail_count", 0) or 0) + 1,
                 "probe_type": final_state.get("probe_type"),
             })
 
-            # 4. 리액션 (PASS_TO_NEXT일 때만)
-            if final_state.get("reaction"):
-                yield self._sse_event("reaction", {
-                    "reaction_text": final_state["reaction"],
-                })
+        return ""
 
-            # 5. 메시지 스트리밍 (RETRY, TAIL_QUESTION일 때)
-            message = final_state.get("generated_message")
-            if message:
-                # 토큰 스트리밍 (문서 스키마와 일치: content만 전송)
-                for char in message:
-                    yield self._sse_event("continue", {
-                        "content": char,
-                    })
+    def _build_done_event(self, final_state: dict) -> str:
+        """최종 done 이벤트 생성"""
+        action = final_state.get("action", SurveyAction.PASS_TO_NEXT)
+        action_value = action.value if hasattr(action, 'value') else str(action)
 
-                # 6. 완료 이벤트 (action에 따라 다른 이벤트 전송)
-                if action_value == SurveyAction.RETRY_QUESTION.value:
-                    # RETRY: retry_request 이벤트 전송 → Spring이 Q_TYPE=RETRY로 저장
-                    yield self._sse_event("retry_request", {
-                        "message": message,
-                        "followup_type": final_state.get("followup_type", "clarify"),
-                    })
-                elif action_value == SurveyAction.TAIL_QUESTION.value:
-                    # TAIL: generate_tail_complete 이벤트 전송 → Spring이 Q_TYPE=TAIL로 저장
-                    yield self._sse_event("generate_tail_complete", {
-                        "message": message,
-                        "tail_question_count": (final_state.get("current_tail_count", 0) or 0) + 1,
-                        "probe_type": final_state.get("probe_type"),
-                    })
-
-            # 7. 최종 완료
-            yield self._sse_event("done", {
-                "status": "completed",
-                "action": action_value,
-                "phase": InterviewPhase.MAIN.value,
-                "question_text": message,
-                "should_end": final_state.get("should_end", False),
-                "end_reason": final_state["end_reason"].value if final_state.get("end_reason") else None,
-                "validity": final_state["validity"].value if final_state.get("validity") else None,
-                "quality": final_state["quality"].value if final_state.get("quality") else None,
-            })
-
-        except Exception as e:
-            logger.error(f"❌ Streaming Error: {e}")
-            yield self._sse_event("error", {"message": str(e)})
+        return self._sse_event("done", {
+            "status": "completed",
+            "action": action_value,
+            "phase": InterviewPhase.MAIN.value,
+            "question_text": final_state.get("generated_message"),
+            "should_end": final_state.get("should_end", False),
+            "end_reason": final_state.get("end_reason").value if final_state.get("end_reason") else None,
+            "validity": final_state["validity"].value if final_state.get("validity") else None,
+            "quality": final_state["quality"].value if final_state.get("quality") else None,
+        })
 
     def _sse_event(self, event_type: str, data: dict) -> str:
         """SSE 이벤트 포맷 생성"""


### PR DESCRIPTION

## 📌 관련 이슈


## ✨ 작업 내용 (Summary)
- InteractionService: astream_events 도입으로 수동 상태 관리 제거 및 이벤트 기반 스트리밍 전환
- SurveyNodes: probe_llm 체인 식별자 추가 및 응답 추출 로직 개선
- SurveySchema: RETRY QuestionType 추가
- LangGraph 상태 오염 방지 및 스트리밍 안정성 강화

## 🚧 의존성 및 주의사항 (Dependencies) ⭐
- [ ] 없음

## ✅ 자가 점검 (Self Checklist)
<!-- 로컬에서 돌려보셨죠? -->
- [ ] 빌드 및 테스트가 통과하였는가?

